### PR TITLE
refactoring parse interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,8 @@ const url = new URL("/lenkan/cesr-js/refs/heads/main/fixtures/geda.cesr", "https
 const response = await fetch(url);
 
 if (response.body) {
-  for await (const message of parse(response.body)) {
-    console.log(message.payload);
-    console.log(message.attachments);
+  for await (const frame of parse(response.body)) {
+    console.log(frame);
   }
 }
 ```
@@ -51,5 +50,4 @@ curl https://raw.githubusercontent.com/lenkan/cesr-js/refs/heads/main/fixtures/g
 
 - [x] Simple parsing of KERI CESR Stream
 - [ ] API for encoding/decoding primitives
-- [ ] Cryptographic verification of CESR Stream
 - [ ] ...

--- a/examples/deno-example/src/main.ts
+++ b/examples/deno-example/src/main.ts
@@ -4,8 +4,7 @@ const url = new URL("/lenkan/cesr-js/refs/heads/main/fixtures/geda.cesr", "https
 const response = await fetch(url);
 
 if (response.body) {
-  for await (const message of parse(response.body)) {
-    console.log(message.payload);
-    console.log(message.attachments);
+  for await (const frame of parse(response.body)) {
+    console.log(frame);
   }
 }

--- a/examples/nodejs-example/package.json
+++ b/examples/nodejs-example/package.json
@@ -2,6 +2,6 @@
   "name": "nodejs-example",
   "private": true,
   "dependencies": {
-    "cesr": "file://../.."
+    "cesr": "file://../../"
   }
 }

--- a/examples/nodejs-example/src/main.js
+++ b/examples/nodejs-example/src/main.js
@@ -5,8 +5,7 @@ const url = new URL("/lenkan/cesr-js/refs/heads/main/fixtures/geda.cesr", "https
 const response = await fetch(url);
 
 if (response.body) {
-  for await (const message of parse(response.body)) {
-    console.log(message.payload);
-    console.log(message.attachments);
+  for await (const frame of parse(response.body)) {
+    console.log(frame);
   }
 }

--- a/src/__unstable__.ts
+++ b/src/__unstable__.ts
@@ -1,4 +1,4 @@
-export { parse, type Message, type MessagePayload } from "./parser.ts";
+export * from "./parser.ts";
 export * from "./version.ts";
 export * from "./codes.ts";
 export * from "./cesr-encoding.ts";

--- a/src/cesr-encoding-vector.test.ts
+++ b/src/cesr-encoding-vector.test.ts
@@ -16,7 +16,7 @@ for (const vector of vectors) {
         assert(result.frame);
         assert.deepEqual(result.frame.code, vector.code);
         assert.deepEqual(result.frame.text, vector.qb64);
-        assert.deepEqual(result.raw, raw);
+        assert.deepEqual(result.frame.raw, raw);
       });
 
       test(`encode qb64 ${vector.type} ${vector.name} - ${vector.qb64.substring(0, 10)}`, () => {
@@ -34,33 +34,33 @@ for (const vector of vectors) {
         assert(result.frame);
         assert.deepEqual(result.frame.code, vector.code);
         assert.deepEqual(result.frame.text, vector.qb64);
-        assert.deepEqual(result.raw, raw);
+        assert.deepEqual(result.frame.raw, raw);
       });
 
       break;
     }
     case "counter_10": {
       test(`decode qb64 ${vector.type} ${vector.name} - ${vector.qb64.substring(0, 10)}`, () => {
-        // TODO: Decode count value for counters
         const result = cesr.decode(vector.qb64, CounterSize_10);
 
         assert(result.frame);
         assert.strictEqual(result.frame.code, vector.code);
         assert.strictEqual(result.frame.text, vector.qb64);
         assert.strictEqual(decodeBase64Int(result.frame.soft), vector.count);
+        assert.strictEqual(result.frame.count, vector.count);
       });
 
       break;
     }
     case "counter_20": {
       test(`decode qb64 ${vector.type} ${vector.name} - ${vector.qb64.substring(0, 10)}`, () => {
-        // TODO: Decode count value for counters
         const result = cesr.decode(vector.qb64, CounterSize_20);
 
         assert(result.frame);
         assert.deepEqual(result.frame.code, vector.code);
         assert.deepEqual(result.frame.text, vector.qb64);
         assert.strictEqual(decodeBase64Int(result.frame.soft), vector.count);
+        assert.strictEqual(result.frame.count, vector.count);
       });
 
       break;

--- a/src/cesr-encoding.test.ts
+++ b/src/cesr-encoding.test.ts
@@ -1,74 +1,59 @@
 import { describe, test } from "node:test";
-import assert from "node:assert";
+import assert from "node:assert/strict";
 import { Buffer } from "node:buffer";
 import { decode, encodeDate, encodeText } from "./cesr-encoding.ts";
 import { CounterSize_10, MatterSize } from "./codes.ts";
 
-function encodeUtf8(input: string) {
-  return new TextEncoder().encode(input);
-}
-
 test("cesr date", () => {
   const result = encodeDate(new Date(Date.parse("2024-11-23T16:02:27.123Z")));
-  assert.strictEqual(result, "1AAG2024-11-23T16c02c27d123000p00c00");
+  assert.equal(result, "1AAG2024-11-23T16c02c27d123000p00c00");
 });
 
 test("CESR string", () => {
   const raw = Buffer.from("1484ea1b126350b4e36f16750a2a30fb85a04d5965", "hex");
   const result = encodeText("7AAA", raw);
 
-  assert.strictEqual(result, "7AAAAAAHFITqGxJjULTjbxZ1Ciow-4WgTVll");
+  assert.equal(result, "7AAAAAAHFITqGxJjULTjbxZ1Ciow-4WgTVll");
 });
 
-test("CESR decode attachment group", () => {
-  const input = encodeUtf8("-VAnABC");
-  const result = decode(input, CounterSize_10);
-
-  assert.deepStrictEqual(result.frame, {
-    type: "counter_10",
-    code: "-V",
-    soft: "An",
-    text: "-VAn",
-  });
-});
-
-test("CESR decode controller sigs", () => {
-  const input = [
-    "-VAi",
-    "-CAB",
-    "BILZrnru0e-0MUmnnjOdWTrZ7OW3sCuk_C_67uYeLsN_",
-    "0BBqX3eR8hNURYuokP3gfJDpcSC41UfFmp2NpTlt4kXwSFR40TXzMll0qtgntwS96U8M2JjTtV_-Ffl5FaGunpEJ",
-  ].join("");
-
-  const result = decode(input, CounterSize_10);
-
-  assert.partialDeepStrictEqual(result.frame, {
-    type: "counter_10",
-    code: "-V",
-    text: "-VAi",
-  });
-  assert.deepStrictEqual(result.n, 4);
-});
-
-test("CESR decode", () => {
+describe("decode variable size", () => {
   const input = "7AAAAAAHFITqGxJjULTjbxZ1Ciow-4WgTVll";
-  const result = decode(input, MatterSize);
 
-  assert.partialDeepStrictEqual(result.frame, {
-    type: "matter",
-    code: "7AAA",
-    text: input,
+  test("decodes text domain", () => {
+    const result = decode(input, MatterSize);
+
+    assert.partialDeepStrictEqual(result, {
+      frame: {
+        type: "matter",
+        code: "7AAA",
+        text: input,
+      },
+      n: 36,
+    });
   });
 
-  assert.strictEqual(result.n, 36);
-});
-
-describe("CESR Decode salt", () => {
-  test("Decode salt", () => {
+  test("decode raw salt", () => {
     const result0 = decode("0ACSTo66vU2CA-j4usUIAEm2");
-    assert.deepStrictEqual(
-      result0.raw,
-      new Uint8Array([146, 78, 142, 186, 189, 77, 130, 3, 232, 248, 186, 197, 8, 0, 73, 182]),
-    );
+
+    assert.partialDeepStrictEqual(result0, {
+      frame: {
+        raw: new Uint8Array([146, 78, 142, 186, 189, 77, 130, 3, 232, 248, 186, 197, 8, 0, 73, 182]),
+      },
+    });
+  });
+
+  test("decode count code", () => {
+    const input = "-VAi";
+
+    const result = decode(input, CounterSize_10);
+
+    assert.partialDeepStrictEqual(result, {
+      frame: {
+        type: "counter_10",
+        code: "-V",
+        text: "-VAi",
+      },
+      n: 4,
+    });
   });
 });

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -1,4 +1,4 @@
-import { parse } from "../parser.ts";
+import { parseMessages } from "../message.ts";
 
 interface Arguments {
   options: Record<string, string | boolean>;
@@ -83,11 +83,11 @@ export async function execute(cli: CommandLineInterface) {
 
   const stream = cli.read(input);
 
-  for await (const chunk of parse(stream)) {
+  for await (const message of parseMessages(stream)) {
     if (app.options["--pretty"]) {
-      console.dir(chunk, { depth: 100, colors: true });
+      console.dir(message, { depth: 100, colors: true });
     } else {
-      console.log(JSON.stringify(chunk));
+      console.log(JSON.stringify(message));
     }
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,1 +1,2 @@
-export { parse, type Message, type MessagePayload } from "./parser.ts";
+export { parse } from "./parser.ts";
+export { Frame, FrameType } from "./cesr-encoding.ts";

--- a/src/message.ts
+++ b/src/message.ts
@@ -1,0 +1,41 @@
+import type { DataObject } from "./data-type.ts";
+import { parse, type ParserInput } from "./parser.ts";
+
+/**
+ * Parses JSON messages with CESR attachments from an incoming stream of bytes.
+ *
+ * @param input Incoming stream of bytes
+ * @returns An async iterable of messages with attachments
+ */
+export async function* parseMessages(input: ParserInput): AsyncIterableIterator<Message> {
+  let payload: MessagePayload | null = null;
+  let group: string | null = null;
+  let attachments: Record<string, string[]> = {};
+
+  for await (const frame of parse(input)) {
+    if (frame.type === "json") {
+      if (payload) {
+        yield { payload, attachments };
+      }
+
+      payload = JSON.parse(frame.text);
+      attachments = {};
+      group = null;
+    } else if (frame.type === "counter_10") {
+      group = frame.code;
+    } else if (group) {
+      attachments[group] = [...(attachments[group] ?? []), frame.text];
+    }
+  }
+
+  if (payload || Object.keys(attachments).length > 0) {
+    yield { payload: payload ?? {}, attachments: attachments ?? [] };
+  }
+}
+
+export type MessagePayload = DataObject;
+
+export interface Message {
+  payload: MessagePayload;
+  attachments: Record<string, string[]>;
+}

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,7 +1,6 @@
 import { parseVersion } from "./version.ts";
 import type { CodeSize } from "./codes.ts";
 import { MatterSize, IndexerSize, CountCode_10, CounterSize_10 } from "./codes.ts";
-import { decodeBase64Int } from "./base64.ts";
 import { decode, type Frame } from "./cesr-encoding.ts";
 
 function concat(a: Uint8Array, b: Uint8Array) {
@@ -51,6 +50,8 @@ class Parser {
       type: "json",
       code: version.protocol,
       soft: "",
+      count: 0,
+      raw: frame,
       text: this.#decoder.decode(frame),
     };
   }
@@ -65,7 +66,7 @@ class Parser {
     this.#buffer = this.#buffer.slice(result.n);
 
     if (result.frame.type === "counter_10") {
-      const count = decodeBase64Int(result.frame.soft);
+      const count = result.frame.count;
       switch (result.frame.code) {
         case CountCode_10.ControllerIdxSigs:
         case CountCode_10.WitnessIdxSigs:


### PR DESCRIPTION
- `parse` only de-frames a stream.
- `parseMessages` collects messages and attachments from a stream of frames
- Adding count and raw to frame inferface to make it easier to consume a stream of frames.